### PR TITLE
Disable show hitmap on click 3d map and use env variable related dataware-tools

### DIFF
--- a/packages/studio-base/environment.ts
+++ b/packages/studio-base/environment.ts
@@ -39,5 +39,9 @@ export function buildEnvironmentDefaults(
     SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? null, // eslint-disable-line no-restricted-syntax
     SIGNUP_API_URL: "https://foxglove.dev/api/signup",
     SLACK_INVITE_URL: "https://foxglove.dev/join-slack",
+    DATAWARE_TOOLS_BACKEND_API_PREFIX: "/api/latest",
+    DATAWARE_TOOLS_AUTH_CONFIG_DOMAIN: "dataware-tools.us.auth0.com",
+    DATAWARE_TOOLS_AUTH_CONFIG_CLIENT_ID: "ETb1RhJEbtXlFgWtaHzl5kPCkaYqhTVl",
+    DATAWARE_TOOLS_AUTH_CONFIG_API_URL: "https://demo.dataware-tools.com/",
   };
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -666,8 +666,29 @@ export default function Layout({
           setShowTopicTree(false);
         }
       },
-      onDoubleClick: (ev: React.MouseEvent, args?: ReglClickInfo) =>
-        handleEvent("onDoubleClick", ev, args),
+      onDoubleClick: (ev: React.MouseEvent, args?: ReglClickInfo) => {
+        handleEvent("onDoubleClick", ev, args);
+        const newClickedObjects =
+          (args?.objects as MouseEventObject[] | undefined) ?? ([] as MouseEventObject[]);
+
+        // With multiple objects we update the selection state with all possible objects
+        if (newClickedObjects.length > 1) {
+          setSelectionState((prevState) => {
+            return {
+              ...prevState,
+              selectedObject: undefined,
+              clickedObjects: newClickedObjects,
+              clickedPosition: {
+                clientX: ev.clientX,
+                clientY: ev.clientY,
+              },
+            };
+          });
+          return;
+        }
+
+        selectObject(newClickedObjects[0]);
+      },
       onExitTopicTreeFocus: () => {
         if (containerRef.current) {
           containerRef.current.focus();

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -223,7 +223,7 @@ function World(
       // Rendering the hitmap is an expensive operation and we want to avoid
       // doing it when the user is dragging the view with the mouse. By ignoring
       // these events, the only way to select an object is when receiving an "onClick" event.
-      disableHitmapForEvents={["onMouseDown", "onMouseMove", "onMouseUp"]}
+      disableHitmapForEvents={["onMouseDown", "onMouseMove", "onMouseUp", "onClick"]}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       onMouseDown={onMouseDown}


### PR DESCRIPTION
## What?
- Disable showing clicked object detail on clicking 3d map
- Use env variable related dataware-tools

## Why?
- Showing clicked object detail on clicking 3d map is slow when 3d map have heavy content
- To use backend dataware-tool's api in foxglove-studio