### PR TITLE
enable HMR when scene-viewer is swapped to local deploy by telepresence

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -40,6 +40,11 @@ const devServerConfig: WebpackConfiguration = {
     //  "[WDS] Disconnected!"
     // Since we are only connecting to localhost, DNS rebinding attacks are not a concern during dev
     allowedHosts: "all",
+    client: {
+      webSocketURL: process.env.USE_LOCAL_DATAWARE_TOOLS
+        ? "wss://dataware-tools.local/scene-viewer/ws"
+        : "auto://0.0.0.0:0/ws",
+    },
   },
 
   plugins: [new CleanWebpackPlugin()],


### PR DESCRIPTION
## What?
telepresence を使って開発してる状態でも scene-viewer の HMR を有効にする

## Why?
HMR が働かないと開発体験が悪いから

## See also
https://www.notion.so/humandatawarelab/PC-telepresence-README-c812878205c049a0acae8cbf905f2e85
https://github.com/hdwlab/dataware-lab/pull/169

## Screenshot or video
![gif](https://user-images.githubusercontent.com/72174933/213670340-9d8601d6-0dce-47d2-88de-47182bfcfa46.gif)
