### PR TITLE
fix: bug that annotations appear in the same record if were not attached to the file.

### DIFF
--- a/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/TagValueSelect.tsx
+++ b/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/TagValueSelect.tsx
@@ -1,0 +1,30 @@
+import { FormControl, InputLabel, MenuItem, Select, SelectProps } from "@mui/material";
+import { TagOptions } from "../types";
+
+export const TagValueSelect = ({
+  tagValue,
+  tagOptions,
+  ...muiSelectProps
+}: {
+  tagValue: string;
+  tagOptions: TagOptions;
+} & SelectProps) => {
+  return (
+    <FormControl fullWidth>
+      <InputLabel id="tag-value-select-label">タグの値</InputLabel>
+      <Select
+        labelId="tag-value-select-label"
+        id="tag-value-select"
+        value={tagValue}
+        label="タグの値"
+        {...muiSelectProps}
+      >
+        {tagOptions.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/content.tsx
+++ b/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/content.tsx
@@ -77,11 +77,11 @@ export const AnnotationListForTagType = ({
         />
         <TagValueSelect
           tagValue={tagValue}
-          tagOptions={(
+          tagOptions={[{ label: "全て", value: "all" }].concat(
             tagOptionsForEachTagType.find(
               (tagTypeOptions) => tagTypeOptions.tag_type.value === tagType,
-            )?.tag_options ?? []
-          ).concat({ label: "全て", value: "all" })}
+            )?.tag_options ?? [],
+          )}
           onChange={(event) => {
             setTagValue(event.target.value as string);
           }}

--- a/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/content.tsx
+++ b/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/content.tsx
@@ -1,12 +1,17 @@
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
 import { Stack } from "@mui/material";
 import { Box } from "@mui/system";
 import { useState } from "react";
 import { useSeekPlayback } from "../../../hooks/useSeekPlayback";
-import { unixTimeToFoxgloveTime } from "../../../logics/time";
+import { foxgloveTimeToUnixTime, unixTimeToFoxgloveTime } from "../../../logics/time";
 import { useDeleteAnnotation, useServerAnnotations, useUpdateAnnotation } from "../apiClients";
 import { AnnotationTable } from "../components/AnnotationTable";
 import { TagOptionsForEachTagType } from "../types";
 import { TagTypeSelect } from "./TagTypeSelect";
+import { TagValueSelect } from "./TagValueSelect";
 
 export type AnnotationListPanelForTagTypeConfig = {
   tagOptionsForEachTagType: TagOptionsForEachTagType;
@@ -24,9 +29,35 @@ export const AnnotationListForTagType = ({
   const { request: updateAnnotation } = useUpdateAnnotation();
   const seekPlayback = useSeekPlayback();
 
+  const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
+  const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.endTime;
+  const startTime = useMessagePipeline(selectStartTime) || { sec: 0, nsec: 0 };
+  const endTime = useMessagePipeline(selectEndTime) || { sec: 0, nsec: 0 };
+
   const [tagType, setTagType] = useState<string>(tagOptionsForEachTagType[0]?.tag_type.value ?? "");
+  const [tagValue, setTagValue] = useState<string>("all");
   const filteredAnnotations = annotations
-    ?.filter((annotation) => annotation.annotation?.tag_type === tagType)
+    ?.filter((annotation) => {
+      const matchTagType = annotation.annotation?.tag_type === tagType;
+      if (!matchTagType) {
+        return false;
+      }
+      const matchTagValue = tagValue === "all" || annotation.annotation?.tags.includes(tagValue);
+      if (!matchTagValue) {
+        return false;
+      }
+      if (!annotation.timestamp_from || !annotation.timestamp_to) {
+        return true;
+      }
+      const matchTimestamp =
+        foxgloveTimeToUnixTime(startTime) <= annotation.timestamp_from &&
+        annotation.timestamp_to <= foxgloveTimeToUnixTime(endTime);
+      if (!matchTimestamp) {
+        return false;
+      }
+
+      return true;
+    })
     .sort((a, b) =>
       a.timestamp_from && b.timestamp_from ? a.timestamp_from - b.timestamp_from : 0,
     );
@@ -36,7 +67,7 @@ export const AnnotationListForTagType = ({
 
   return (
     <Stack overflow="hidden" height="100%">
-      <Box flexGrow={0} flexShrink={0}>
+      <Stack flexGrow={0} flexShrink={0} direction="row">
         <TagTypeSelect
           tagType={tagType}
           tagTypeOptions={tagOptionsForEachTagType.map((tagTypeOptions) => tagTypeOptions.tag_type)}
@@ -44,7 +75,18 @@ export const AnnotationListForTagType = ({
             setTagType(event.target.value as string);
           }}
         />
-      </Box>
+        <TagValueSelect
+          tagValue={tagValue}
+          tagOptions={(
+            tagOptionsForEachTagType.find(
+              (tagTypeOptions) => tagTypeOptions.tag_type.value === tagType,
+            )?.tag_options ?? []
+          ).concat({ label: "全て", value: "all" })}
+          onChange={(event) => {
+            setTagValue(event.target.value as string);
+          }}
+        />
+      </Stack>
       <Box flexGrow={1} flexShrink={1} height="100%" overflow="auto">
         <AnnotationTable
           highlightCurrentAnnotation

--- a/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/content.tsx
+++ b/packages/hdl-panels/src/panels/panelsForCoMLOpsPromptEngineeringEx2/AnnotationListForTagType/content.tsx
@@ -4,7 +4,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { Stack } from "@mui/material";
 import { Box } from "@mui/system";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSeekPlayback } from "../../../hooks/useSeekPlayback";
 import { foxgloveTimeToUnixTime, unixTimeToFoxgloveTime } from "../../../logics/time";
 import { useDeleteAnnotation, useServerAnnotations, useUpdateAnnotation } from "../apiClients";
@@ -36,6 +36,11 @@ export const AnnotationListForTagType = ({
 
   const [tagType, setTagType] = useState<string>(tagOptionsForEachTagType[0]?.tag_type.value ?? "");
   const [tagValue, setTagValue] = useState<string>("all");
+
+  useEffect(() => {
+    setTagValue("all");
+  }, [tagType, tagOptionsForEachTagType]);
+
   const filteredAnnotations = annotations
     ?.filter((annotation) => {
       const matchTagType = annotation.annotation?.tag_type === tagType;


### PR DESCRIPTION
## What?
時間幅を持ったアノテーションをつけるパネルで以下を実施
- 同じレコード内で、本来そのファイルにつけていないアノテーションが表示されるバグの修正
- タグの値による絞り込み機能を、種類ごとのタグを表示するパネルに実装

## Why? 
アノテーション作業を円滑に実行して欲しいので

## See also
https://human-dataware-lab.slack.com/archives/C07DYCHDT8R/p1725495219871219